### PR TITLE
add: rapporter.net to the list of online frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Tools for Working with the Web from R
     interacting with popular projects such as
     [shiny](http://cran.r-project.org/whttp://cran.r-project.org/web/packages/shiny/index.html)
     and [sauceLabs](http://saucelabs.com).
+-   [rapporter.net](http://rapporter.net) provides an online environment
+    (SaaS) to host and run [rapport](http://cran.r-project.org/web/packages/websockets/index.html)
+    statistical report templates in the cloud.
 
 ### JavaScript
 

--- a/WebTechnologies.ctv
+++ b/WebTechnologies.ctv
@@ -121,6 +121,9 @@ The <a href="http://www.omegahat.org/WADL/">WADL</a> package provides tools to p
 The <a href="http://www.omegahat.org/RDCOMServer/">RDCOMServer</a> provides a mechanism to export R objects as (D)COM objects in Windows. It can be used along with the <a href="http://www.omegahat.org/RDCOMClient/">RDCOMClient</a> package which provides user-level access from R to other COM servers.
 </li>
 <li>The <a href="https://github.com/johndharrison/RSelenium">RSelenium</a> package (not on CRAN) provides a set of R bindings for the Selenium 2.0 webdriver using the [JsonWireProtocol](http://code.google.com/p/selenium/wiki/JsonWireProtocol). Selenium automates browsers. Using RSelenium you can automate browsers locally or remotely. This can aid in automated application testing, load testing and web scraping. Examples are given interacting with popular projects such as [shiny](http://cran.r-project.org/web/packages/shiny/index.html) and [sauceLabs](http://saucelabs.com).</li>
+<li>
+<a href="http://rapporter.net">rapporter.net</a> provides an online environment (SaaS) to host and run <pkg>rapport</pkg> statistical report templates in the cloud.
+</li>
 </ul>
 
 <p><strong>JavaScript</strong></p>
@@ -711,6 +714,7 @@ The <a href="https://github.com/jbryer/qualtrics">qualtrics</a> package provides
 <pkg>quantmod</pkg>
 <pkg>rAltmetric</pkg>
 <pkg>raincpc</pkg>
+<pkg>rapport</pkg>
 <pkg>rbhl</pkg>
 <pkg>Rbitcoin</pkg>
 <pkg>Rcolombos</pkg>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@ document.write('<a h'+'ref'+'="ma'+'ilto'+':'+e+'">'+'send Scott an email'+'<\/'
 <li>The <a href="http://www.omegahat.org/WADL/">WADL</a> package provides tools to process Web Application Description Language (WADL) documents and to programmatically generate R functions to interface to the REST methods described in those WADL documents.</li>
 <li>The <a href="http://www.omegahat.org/RDCOMServer/">RDCOMServer</a> provides a mechanism to export R objects as (D)COM objects in Windows. It can be used along with the <a href="http://www.omegahat.org/RDCOMClient/">RDCOMClient</a> package which provides user-level access from R to other COM servers.</li>
 <li>The <a href="https://github.com/johndharrison/RSelenium">RSelenium</a> package (not on CRAN) provides a set of R bindings for the Selenium 2.0 webdriver using the <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol">JsonWireProtocol</a>. Selenium automates browsers. Using RSelenium you can automate browsers locally or remotely. This can aid in automated application testing, load testing and web scraping. Examples are given interacting with popular projects such as <a href="http://cran.r-project.org/whttp://cran.r-project.org/web/packages/shiny/index.html">shiny</a> and <a href="http://saucelabs.com">sauceLabs</a>.</li>
+<li><a href="http://rapporter.net">rapporter.net</a> provides an online environment (SaaS) to host and run <pkg>rapport</pkg> statistical report templates in the cloud.</li>
 </ul>
 <h3 id="javascript">JavaScript</h3>
 <ul>


### PR DESCRIPTION
Please note that I had some difficulties with running `make`, so I updated the html and README files manually:

```
[~/projects/webservices]% make
Rscript -e 'library(ctv); ctv2html("WebTechnologies.ctv")'
Loading required package: XML
Loading required package: methods
Error: XML content does not seem to be XML: 'WebTechnologies.ctv'
Execution halted
Makefile:7: recipe for target 'dorstuff' failed
make: *** [dorstuff] Error 1
```

I would be extremely happy to see this pull request merged, please let me know how I should improve it. Thanks for maintaining the CRAN Task View!
