### PR TITLE
ignore environment and profile files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ getdumber:
 	sed 's@<li class="removeme">.\+<\/li>@ @g' WebTechnologies.ctv > WebTechnologiesDumber.ctv
 
 dorstuff:	
-	Rscript -e 'library(ctv); ctv2html("WebTechnologies.ctv")'
+	Rscript --vanilla -e 'library(ctv); ctv2html("WebTechnologies.ctv")'
 
 sed:
 	mv WebTechnologies.html doc.html


### PR DESCRIPTION
This pull request provides a fix for the problem I faced at https://github.com/ropensci/webservices/pull/56

Details: I set the working directory to `/tmp` in my `.Rprofile` -- that's why `XML::xmlTreeParse` cannot find `WebTechnologies.ctv`. Adding `--vanilla` option to the `Rscript` call in the `Makefile` would also help some other possible issues.

Please feel free to merge or close.
