### PR TITLE
rephrase OmegaHat link

### DIFF
--- a/WebTechnologies.md
+++ b/WebTechnologies.md
@@ -763,9 +763,7 @@ For specialized situations, the following resources may be useful:
 
 ### Links
 
-- The "Omega Project for Statistical Computing"
-  was a collection of open-source packages from authors in (or close to) the R Core Team,
-  especially for web-based technologies, actively developed 1998-2013.
-  Some are still referenced on this task view.
-  The (mostly dormant) packages are available at
-  <https://github.com/omegahat>.
+- [Omega Project for Statistical Computing](https://github.com/omegahat):
+  Collection of open-source packages from authors in (or close to) the R Core Team,
+  especially for web-based technologies, that was actively developed 1998-2013.
+  Some of the (mostly dormant) packages are still referenced on this task view.


### PR DESCRIPTION
Fixes #556

Will @wibeasley thanks for catching this! I had just removed the one usage of `ohat(...)` that remained in one of the other task views but overlooked that you had it listed in the "Links" section.

The reason that the link to github.com/omegahat failed was that it used `<...>` syntax but the current reader expects `[...](...)]` syntax for the links. I have rephrased this in this PR.

Hopefully the GHA succeds now.